### PR TITLE
add support for the repatriation filter when downloading records

### DIFF
--- a/pygbif/occurrences/download.py
+++ b/pygbif/occurrences/download.py
@@ -415,4 +415,5 @@ key_lkup = {'taxonKey': 'TAXON_KEY',
             'collectionCode': 'COLLECTION_CODE',
             'issue': 'ISSUE',
             'mediatype': 'MEDIA_TYPE',
-            'recordedBy': 'RECORDED_BY'}
+            'recordedBy': 'RECORDED_BY',
+            'repatriated': 'REPATRIATED'}


### PR DESCRIPTION
#32 

We just started using pygbif here at GBIF Norway, so I'm not too familiar with the code yet, but this trivial change should at least enable the repatriation filter when using the occurrence download api~